### PR TITLE
Resolve paths relative to the current path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    byebug (11.1.1)
     diff-lcs (1.3)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
@@ -44,10 +45,11 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  byebug
   easy_yaml!
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/easy_yaml.gemspec
+++ b/easy_yaml.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'byebug'
 end

--- a/lib/easy_yaml/yaml_loader.rb
+++ b/lib/easy_yaml/yaml_loader.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'pathname'
 require 'erb'
 
 module EasyYAML
@@ -29,7 +30,7 @@ module EasyYAML
     end
 
     def file_path
-      Pathname.new File.expand_path(yaml_file_path, __dir__)
+      Pathname.new File.expand_path(yaml_file_path, Dir.pwd)
     end
 
     def yaml_file

--- a/spec/easy_yaml/yaml_loader_spec.rb
+++ b/spec/easy_yaml/yaml_loader_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe EasyYAML::YAMLLoader do
   let(:yaml_examples_dir) { '../../spec/examples' }
 
+  before do
+    Dir.chdir(__dir__)
+  end
+
   describe '#new' do
     it 'requires a path argument' do
       subject = described_class.new("#{yaml_examples_dir}/simple.yml")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'byebug'
 require 'easy_yaml'
 
 RSpec.configure do |config|


### PR DESCRIPTION
This allows the gem to be used outside of Rails. Without this change
relative paths to a yaml file are expanded to the path the gem is
installed in.